### PR TITLE
Remove name_prefix length validation 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,12 +26,6 @@ provider "random" {
   version = "1.2.0"
 }
 
-# Throws error when name_prefix is exceeding the maximum character limit from AWS
-resource "null_resource" "name_prefix_is_too_long" {
-  count                                                                                                = "${local.prefix_length > local.resource_max_character_length && local.resource_max_character_length != 0 ? 1 : 0}"
-  "\n\nYour name_prefix is too long.\nThe limit is ${local.resource_max_character_length} characters." = true
-}
-
 # Throws error when resource_type is not suppported by the module yet
 resource "null_resource" "unsupported_resource_type" {
   count                                                                                           = "${local.resource_max_character_length == 0 ? 1 : 0}"


### PR DESCRIPTION
Remove to prevent bug where the validation will always fail if name_prefix contains interpolation.