### PR TITLE
Added support for FIFO SQS Queues. Added mandatory .fifo suffix for FIFO Queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Supported Resources
 * s3_bucket
 * sns_topic
 * sqs_queue
+* fifo_sqs_queue
 
 
 Contributing

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,9 @@ locals {
 
   random_max_byte_length = "${(local.resource_max_character_length - length(local.prefix)) / 2}"
   random_byte_length     = "${min(local.max_byte_length, local.random_max_byte_length)}"
+
+  suffix_for_resource_name = "${lookup(local.mandatory_suffix_for_resource_name, var.resource_type, "")}"
+  final_name               = "${format("%s%s", random_id.this.hex, local.suffix_for_resource_name)}"
 }
 
 # Null Provider. This module was created on 2018/04/10

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "name" {
   description = "The generated name with random_id presented in padded hexadecimal digits as suffix."
-  value       = "${random_id.this.hex}"
+  value       = "${local.final_name}"
 }

--- a/resources.tf
+++ b/resources.tf
@@ -30,5 +30,10 @@ locals {
     "security_group"        = 255 # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSecurityGroup.html
     "sns_topic"             = 256 # https://docs.aws.amazon.com/sns/latest/api/API_CreateTopic.html
     "sqs_queue"             = 80  # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html
+    "fifo_sqs_queue"        = 75  #https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html
+  }
+
+  mandatory_suffix_for_resource_name = {
+    fifo_sqs_queue          = ".fifo"
   }
 }


### PR DESCRIPTION
Added Support for FIFO Queues. FIFO Queues name must end with `.fifo` as mentioned [here](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html) and should be of length not more than 80 characters.