### PR TITLE
relax provider versions for terraform 0.12 readiness

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,12 +18,12 @@ locals {
 
 # Null Provider. This module was created on 2018/04/10
 provider "null" {
-  version = "~> 1.0.0"
+  version = ">= 1.0.0, < 3.0.0"
 }
 
 # Random Provider. This module was created on 2018/04/10
 provider "random" {
-  version = "~> 1.2.0"
+  version = ">= 1.2.0, < 3.0.0"
 }
 
 # Throws error when resource_type is not suppported by the module yet

--- a/main.tf
+++ b/main.tf
@@ -18,12 +18,12 @@ locals {
 
 # Null Provider. This module was created on 2018/04/10
 provider "null" {
-  version = ">=1.0.0"
+  version = "~> 1.0.0"
 }
 
 # Random Provider. This module was created on 2018/04/10
 provider "random" {
-  version = ">=1.2.0"
+  version = "~> 1.2.0"
 }
 
 # Throws error when resource_type is not suppported by the module yet

--- a/main.tf
+++ b/main.tf
@@ -18,12 +18,12 @@ locals {
 
 # Null Provider. This module was created on 2018/04/10
 provider "null" {
-  version = "1.0.0"
+  version = ">=1.0.0"
 }
 
 # Random Provider. This module was created on 2018/04/10
 provider "random" {
-  version = "1.2.0"
+  version = ">=1.2.0"
 }
 
 # Throws error when resource_type is not suppported by the module yet


### PR DESCRIPTION
If provider versions are fixed inside modules, parent terraform scripts cannot specify a different version as it will cause version conflicts.

Instead of removing provider versions all together, it might be beneficial to relax the versioning from a strict version to a greater than version. This hopefully sends the message that this modules will work with a provider version of the at least specified version.