### PR TITLE
Remove custom workaround to validate resource_type

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   traveloka/techops
+*   @traveloka/techops

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Don't forget to also add the resource that you added to [Supported Resources lis
 
 Terraform Version
 -----------------
-This module was created using Terraform 0.11.6. 
-So to be more safe, Terraform version 0.11.6 or newer is required to use this module.
+This module was originally created using Terraform 0.11.6.
+Terraform version 0.11.6 or newer is required to use this module.
 
 
 Authors

--- a/examples/autoscaling-policy-example/main.tf
+++ b/examples/autoscaling-policy-example/main.tf
@@ -8,7 +8,7 @@ module "this" {
   source = "../../"
 
   name_prefix   = "${local.service_name}-${local.cluster_role}-${local.scaling_description}"
-  resource_type = "scaling_policy"
+  resource_type = "autoscaling_policy"
 
   keepers = {
     FirstKeeper  = "TestValue"

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,9 @@
+# This module was created using Terraform 0.11.6 on 2018/04/10
+# Tested working on Terraform 0.12.0 on 2019/05/28
+terraform {
+  required_version = ">= 0.11.6, < 0.13.0"
+}
+
 locals {
   # Randomly generated hexadecimal value should not exceed 16 characters.
   max_byte_length = 8
@@ -7,7 +13,7 @@ locals {
   # * var.name_prefix = "txtdata-app"    -->  prefix = "txtdata-app-"
   # * var.name_prefix = "txtdata-app-"   -->  prefix = "txtdata-app-"
   # * var.name_prefix = "txtdata-app--"  -->  prefix = "txtdata-app--"   
-  prefix = "${substr(var.name_prefix, -1, 1) == "-" ? substr(var.name_prefix, 0, length(var.name_prefix)-1) : var.name_prefix}-"
+  prefix = "${substr(var.name_prefix, -1, 1) == "-" ? substr(var.name_prefix, 0, length(var.name_prefix) - 1) : var.name_prefix}-"
 
   prefix_length                 = "${length(local.prefix)}"
   resource_max_character_length = "${lookup(local.max_character_length, var.resource_type, 0)}"
@@ -16,20 +22,9 @@ locals {
   random_byte_length     = "${min(local.max_byte_length, local.random_max_byte_length)}"
 }
 
-# Null Provider. This module was created on 2018/04/10
-provider "null" {
-  version = ">= 1.0.0, < 3.0.0"
-}
-
 # Random Provider. This module was created on 2018/04/10
 provider "random" {
   version = ">= 1.2.0, < 3.0.0"
-}
-
-# Throws error when resource_type is not suppported by the module yet
-resource "null_resource" "unsupported_resource_type" {
-  count                                                                                           = "${local.resource_max_character_length == 0 ? 1 : 0}"
-  "\n\nCurrently supported resource types: \n* ${join("\n* ", keys(local.max_character_length))}" = true
 }
 
 # Provides random id in hex format


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


Fixes #26 


Release note for [CHANGELOG](https://github.com/rafikurnia/sandbox/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from `terraform plan` command from one of the examples on your branch after `terraform apply` has been successfully performed on the latest release:

```
$ terraform plan

...
```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: -
--->
