### PR TITLE
CTD-211 - Terraform module shoudn't have provider block.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ This module will help you to generate a unique resource name by adding `random_i
 You need to know what resource you want to provision (`resource_type`) and what the name prefix (`name_prefix`) is. Then provide the information to this module's variables:
 
 ```hcl
+provider "random" {
+  version = ">= 1.2.0, < 3.0.0"
+}
+
 module "aws-resource-naming_lambda_role" {
   source        = "github.com/traveloka/terraform-aws-resource-naming"
   version       = "v0.17.1"

--- a/examples/autoscaling-policy-example/main.tf
+++ b/examples/autoscaling-policy-example/main.tf
@@ -1,3 +1,7 @@
+provider "random" {
+  version = ">= 1.2.0, < 3.0.0"
+}
+
 locals {
   service_name        = "txtdata"
   cluster_role        = "app"

--- a/examples/postgres-parameter-group/main.tf
+++ b/examples/postgres-parameter-group/main.tf
@@ -1,3 +1,7 @@
+provider "random" {
+  version = ">= 1.2.0, < 3.0.0"
+}
+
 locals {
   service_name = "txtdata"
   db_engine    = "postgres"

--- a/main.tf
+++ b/main.tf
@@ -22,11 +22,6 @@ locals {
   random_byte_length     = "${min(local.max_byte_length, local.random_max_byte_length)}"
 }
 
-# Random Provider. This module was created on 2018/04/10
-provider "random" {
-  version = ">= 1.2.0, < 3.0.0"
-}
-
 # Provides random id in hex format
 resource "random_id" "this" {
   prefix      = "${local.prefix}"


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Problem description:
Developers constantly receive error, in this format, when upgrading some Terraform modules:
```       
* module.**.random_id.this: configuration for module.**.provider.random is not present; a provider configuration block is required for all operations
```
Usually, this was resolved by running terraform state rm for all module use random provider,or terraform state mv if the module was renamed. However, it has been a huge inconvenient for CT DevOps engineers with `terraform apply` permission to do it for other CorpTech developers with only `terraform plan` permission.

A bit more on pro and cons of this approach from perspective of module user:

Pros:

1. Reduce the number of manual works from infra delegates. Right now the only way to fix this issue is to run `terraform state rm` or `terraform state mv`, which only infra delegate (of both shared account and multi-account can do - or should do).
2. Since there is no extra hop, developers can get their Terraform executed quicker.
3. Developers and infra delegates can freely upgrade their providers without having to wait for site-infra to release new versions, check if there is any breaking change and then upgrade the whole Terraform modules (this has a bit of both in pro and cons, of course).

Cons:

1. If developers/infra delegates forget to mention provider blocks, Terraform will throw an obscure error message --> However, the error message mentioned above in this PR is not any clearer, although it will show up less.
2. It is harder for Site-Infra now to force people to upgrade their providers. However, I think it will not be very different from the current situation.

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-resource-naming/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Developer will now have to specify provider block at their Terraform stack, instead of Terraform module creator specify this block in their Terraform module.

FEATURES:

* N.A

ENHANCEMENTS:

* N.A

BUG FIXES:

* When developer upgrade a Terraform module which satisfy these condition:
- This terraform module use `terraform-aws-resource-naming` to name their resources, like this https://github.com/traveloka/terraform-aws-autoscaling/blob/v0.1.8-rolling/main.tf#L6-L22.
- They decided to remove/rename this module block in later release
This error will appear
---
* module.**.random_id.this: configuration for module.**.provider.random is not present; a provider configuration block is required for all operations
---
This PR will solve this problem. FYI, the root cause was well explained in this comment: https://github.com/hashicorp/terraform/issues/17365#issuecomment-366118431

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
