### PR TITLE
Add resource naming for secrets manager secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This module will help you to generate a unique resource name by adding `random_i
 - lb
 - lb_target_group
 - s3_bucket
+- secretsmanager_secret
 - security_group
 - sns_topic
 - sqs_queue

--- a/resources.tf
+++ b/resources.tf
@@ -29,6 +29,7 @@ locals {
     "lb"                                  = "32"  # https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateLoadBalancer.html
     "lb_target_group"                     = "32"  # https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html
     "s3_bucket"                           = "63"  # https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
+    "secretsmanager_secret"               = "256" # https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_limits.html
     "security_group"                      = "255" # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSecurityGroup.html
     "sns_topic"                           = "256" # https://docs.aws.amazon.com/sns/latest/api/API_CreateTopic.html
     "sqs_queue"                           = "80"  # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html


### PR DESCRIPTION
### Community Note
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

This PR introduces a new resource (Secrets Manager Secret) for effective naming.

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-resource-naming/blob/master/CHANGELOG.md):

```release-note
NOTES:

None

FEATURES:

* **New Source:** `aws_secretsmanager_secret` ([#https://www.terraform.io/docs/providers/aws/r/secretsmanager_secret.html](./))

ENHANCEMENTS:

None

BUG FIXES:

None
```

***

Output from `terraform plan` command from changes you propose.

```
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + module.this.random_id.this
      id:          <computed>
      b64:         <computed>
      b64_std:     <computed>
      b64_url:     <computed>
      byte_length: "8"
      dec:         <computed>
      hex:         <computed>
      prefix:      "ecicfp-"


Plan: 1 to add, 0 to change, 0 to destroy.


```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
