### PR TITLE
Add floor function for random_max_byte_length to round the result

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ locals {
   prefix_length                 = length(local.prefix)
   resource_max_character_length = lookup(local.max_character_length, var.resource_type, 0)
 
-  random_max_byte_length = (local.resource_max_character_length - length(local.prefix)) / 2
+  random_max_byte_length = floor((local.resource_max_character_length - length(local.prefix)) / 2)
   random_byte_length     = min(local.max_byte_length, local.random_max_byte_length)
 }
 


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #0000

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-resource-naming/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

BUG FIXES:

* Prevent error from an odds length of random id for IAM role name
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
